### PR TITLE
support: Now support SSM Documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ dist
 # Serverless directories
 .serverless/
 serverless.yml
+slsFile*.yml
 
 # FuseBox cache
 .fusebox/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # ChangeLog
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - 2024-08-18
+
+### Changed
+- Support for AWS Documents
+- Fix: test for missig SystemsManager property
+- Fix: test for missig parameter property
+- Centralized validations in proper module
+- Fix: replace custop prop for systemsManager in README
+- Add: Documents support documentation in README
+
 ## [1.0.1] - 2024-08-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ plugins:
 name, type and value are mandatory
 
 ```yml 
-custom:
+systemsManager:
   parameters:
     - name: /name/parameter
       type: String
@@ -40,7 +40,7 @@ custom:
 
 * Add Description
 ```yml 
-custom:
+systemsManager:
   parameters:
     - name: /name/parameter
       type: String
@@ -52,7 +52,7 @@ custom:
 
 Tier must be 'Advanced'
 ```yml 
-custom:
+systemsManager:
   parameters:
     - name: /name/parameter
       type: String
@@ -77,7 +77,7 @@ custom:
 
 * Parameter Pattern
 ```yml 
-custom:
+systemsManager:
   parameters:
     - name: /name/parameter
       type: String
@@ -89,7 +89,7 @@ custom:
 
 text or aws:ec2:image, text is default
 ```yml 
-custom:
+systemsManager:
   parameters:
     - name: /name/parameter1
       type: String
@@ -99,7 +99,7 @@ custom:
 
 * Define Multiple Parameters
 ```yml 
-custom:
+systemsManager:
   parameters:
     - name: /name/parameter1
       type: String
@@ -107,6 +107,123 @@ custom:
     - name: /name/parameter2
       type: String
       value: Value
+```
+
+### Documents
+
+Creates a Systems Manager (SSM) document in AWS Systems Manager for D
+document types:
+
+ApplicationConfiguration | ApplicationConfigurationSchema | Automation | Automation.ChangeTemplate | ChangeCalendar | CloudFormation | Command | DeploymentStrategy | Package | Policy | ProblemAnalysis | ProblemAnalysisTemplate | Session
+
+
+* Mandatory Properties
+
+name,type,content
+```yml 
+systemsManager:
+  documents:
+    - name: testDocument
+      type: Command
+      content:
+        schemaVersion: "2.2"
+        description: "Command Document Example"
+        mainSteps:
+        - action: "aws:runPowerShellScript"
+          name: "example"
+          inputs:
+            runCommand:
+            - "Write-Output {{Message}}"
+```
+
+* Define content in other file
+
+It's recomended to have a seperate file with document's content to improve readability
+
+```yml 
+systemsManager:
+  documents:
+    - name: testDocument
+      type: Command
+      content:
+       ${file(testDocumentContent.yml)}
+```
+
+* Define versioning
+
+For versioning porpuse, update Method "NewVersion" will automatically version your doucment
+```yml 
+systemsManager:
+  documents:
+    - name: testDocument
+      type: Command
+      updateMethod: NewVersion
+      content:
+       ${file(testDocumentContent.yml)}
+```
+
+* Define Target type
+
+```yml 
+systemsManager:
+  documents:
+    - name: testDocument
+      type: Command
+      targetType: /AWS::EC2::Instance
+      content:
+       ${file(testDocumentContent.yml)}
+```
+
+* Define Attachments
+
+If attachments are defined, key and values are mandatory
+```yml 
+systemsManager:
+  documents:
+    - name: testDocument
+      type: Command
+      attachments:
+        - key: AttachmentReference
+          name: testFile
+          values: 
+            - "arn:aws:ssm:us-east-2:111122223333:document/OtherAccountDocument/3/their-file.py" 
+      content:
+       ${file(testDocumentContent.yml)}
+```
+
+* Define Required Documents
+
+If requires are defined, name it's mandatory
+```yml 
+systemsManager:
+  documents:
+    - name: testDocument
+      type: Command
+      requires:
+        - version: $LATEST
+          name: requiredDocument
+      content:
+       ${file(testDocumentContent.yml)}
+```
+
+* Define multiple documents
+
+It can be created many documents or documents types as you require
+```yml 
+systemsManager:
+  documents:
+    - name: testDocument
+      type: Command
+      content:
+       ${file(testDocumentContent.yml)}
+    - name: testSession
+      type: Session
+      content:
+       ${file(tesSessionContent.yml)}
+    - name: testSession
+      type: Automation
+      content:   
+       ${file(tesAutomationContent.yml)}
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Serverless Framework v3 or later is required
   - [Install](#Install)
   - [Configure](#Configure)
     - [Parameter Store](#Parameter-Store) 
+    - [Documents](#Documents)
   - [License](#License) 
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Serverless Systems Manager
-This is a serverless plugin that will help you creating the necesary resources for AWS Systems Manager. 
+This is a serverless plugin that will help you creating the necessary resources for AWS Systems Manager. 
 
 ## Requierement
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,8 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 const packageParameters = require('./package/parameters/packageParameters');
-
+const packageDocuments= require('./package/documents/packageDocuments');
+const validations= require('./utils/validations');
 class ServerlessSystemsManager {
   constructor(serverless) {
     this.serverless = serverless;
@@ -14,13 +15,15 @@ class ServerlessSystemsManager {
 
     Object.assign(
       this,
-      packageParameters
+      validations,
+      packageParameters,
+      packageDocuments
     )
 
     this.hooks = {
       'package:compileEvents': ()=> BbPromise.bind(this)
       .then(this.packageParameters)
-      
+      .then(this.packageDocuments)
     };
     
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -2,10 +2,15 @@
 
 const ServerlessSystemsManager = require('./index');
 const packageParameters = require('./package/parameters/packageParameters');
+const packageDocuments = require('./package/documents/packageDocuments');
 const BbPromise = require('bluebird');
 
 jest.mock('./package/parameters/packageParameters', () => ({
   packageParameters: jest.fn().mockResolvedValue('mockedValue'),
+}));
+
+jest.mock('./package/documents/packageDocuments', () => ({
+  packageDocuments: jest.fn().mockResolvedValue('mockedValue'),
 }));
 
 describe('ServerlessSystemsManager', () => {
@@ -41,5 +46,6 @@ describe('ServerlessSystemsManager', () => {
     await hookFunction();
 
     expect(packageParameters.packageParameters).toHaveBeenCalled();
+    expect(packageDocuments.packageDocuments).toHaveBeenCalled();
   });
 });

--- a/lib/package/documents/packageDocuments.js
+++ b/lib/package/documents/packageDocuments.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const _ = require('lodash');
+const BbPromise = require('bluebird');
+
+module.exports = {
+  packageDocuments() {
+    if(this.serverless.configurationInput.systemsManager != null){
+      if(this.serverless.configurationInput.systemsManager.documents != null){
+        this.validateParameterArray(this.serverless.configurationInput.systemsManager.documents).forEach(documentsConf => {
+          this.validateMandatoryPropValue(documentsConf.name, "Name")
+          this.validateReservedNamePrefix(documentsConf.name, [ "aws", "amazon", "amzn", "AWSEC2", "AWSConfigRemediationAWSSupport" ])
+          this.validateMandatoryPropValue(documentsConf.type, "Type")
+          this.validateMandatoryPropValue(documentsConf.content, "Content")
+          const logicalId = `${documentsConf.name.replace(/[^\w]/gi, '')}Command`
+
+          const parameterTemplate = `
+            {
+              "Type" : "AWS::SSM::Document",
+              "Properties" : {
+                "DocumentFormat" : "JSON",
+                "DocumentType" : "${documentsConf.type}",
+                "Name": "${documentsConf.name}"
+              }
+            }
+          `;
+     
+          const parseTemplate = JSON.parse(parameterTemplate)
+          parseTemplate.Properties.Content = documentsConf.content
+
+          if(documentsConf.targetType){
+            parseTemplate.Properties.TargetType = documentsConf.targetType
+          }
+
+          if(documentsConf.updateMethod){
+            parseTemplate.Properties.UpdateMethod = documentsConf.updateMethod
+          }
+
+          if(documentsConf.versionName){
+            parseTemplate.Properties.VersionName = documentsConf.versionName
+          }
+
+          if(documentsConf.attachments){
+            const attachments = []
+            this.validateParameterArray(documentsConf.attachments).forEach(attachmentsConf => {
+              let attachment = {}
+              
+              if(attachmentsConf.name){
+                attachment.Name = attachmentsConf.name
+              }
+              this.validateMandatoryPropValue(attachmentsConf.values, "Attachments/Values")
+              attachment.Values = attachmentsConf.values
+              
+              this.validateMandatoryPropValue(attachmentsConf.key, "Attachments/Name")
+              attachment.Key = attachmentsConf.key
+              attachments.push(attachment)
+            })
+            parseTemplate.Properties.Attachments = attachments
+          }
+
+          if(documentsConf.requires){
+            const requires = []
+            this.validateParameterArray(documentsConf.requires).forEach(requiresConf => {
+              let require = {}
+              this.validateMandatoryPropValue(requiresConf.name, "Requires/Name")
+              require.Name = requiresConf.name
+              if(requiresConf.version){
+                require.Version = requiresConf.version
+              }
+              requires.push(require)
+            })
+            parseTemplate.Properties.Requires = requires
+          }
+
+
+          const newParameterObject = {
+            [logicalId]:parseTemplate,
+          };
+
+          _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+              newParameterObject);
+        })
+      }
+    }
+    return BbPromise.resolve();
+  }
+
+  
+};

--- a/lib/package/documents/packageDocuments.test.js
+++ b/lib/package/documents/packageDocuments.test.js
@@ -1,0 +1,237 @@
+'use strict';
+const packageDocuments = require('./packageDocuments');
+const validations = require('../../utils/validations'); 
+
+describe('packageDocuments', () => {
+  let serverlessMock;
+  let moduleInstance;
+
+  beforeEach(() => {
+    serverlessMock = {
+      configurationInput: {
+        systemsManager: {
+          documents: []
+        }
+      },
+      service: {
+        provider: {
+          compiledCloudFormationTemplate: {
+            Resources: {}
+          }
+        }
+      },
+      classes: {
+        Error: class extends Error {},
+      }
+    };
+
+    moduleInstance = Object.create(packageDocuments);
+    moduleInstance.serverless = serverlessMock;
+    moduleInstance.validateParameterArray = validations.validateParameterArray
+    moduleInstance.validateMandatoryPropValue = validations.validateMandatoryPropValue
+    moduleInstance.validateReservedNamePrefix = validations.validateReservedNamePrefix
+  });
+
+  describe('packageDocuments', () => {
+    it('should do nothing if systemsManager is not provided', async () => {
+      moduleInstance.serverless.configurationInput.systemsManager = null;
+
+      const value = await moduleInstance.packageDocuments();
+
+      expect(value).toBeUndefined()
+    });
+    it('should do nothing if documents is not provided', async () => {
+      moduleInstance.serverless.configurationInput.systemsManager = {
+        documents: null
+      };
+
+      const value = await moduleInstance.packageDocuments();
+
+      expect(value).toBeUndefined()
+    });
+
+    it('should add parameter to CloudFormation template', async () => {
+      moduleInstance.serverless.configurationInput.systemsManager.documents = [
+        {
+          name: 'test',
+          type: 'Command',
+          content: {}
+        }
+      ];
+
+      await moduleInstance.packageDocuments();
+
+      expect(moduleInstance.serverless.service.provider.compiledCloudFormationTemplate.Resources).toHaveProperty('testCommand');
+      const parameter = moduleInstance.serverless.service.provider.compiledCloudFormationTemplate.Resources.testCommand;
+      
+      expect(parameter).toHaveProperty('Type', 'AWS::SSM::Document');
+      expect(parameter.Properties).toHaveProperty('Name', 'test');
+      expect(parameter.Properties).toHaveProperty('DocumentType', 'Command');
+      expect(parameter.Properties).toHaveProperty('DocumentFormat', 'JSON');
+      expect(parameter.Properties).toHaveProperty('Content', {});
+    });
+
+    it('should add target type to CloudFormation template', async () => {
+      moduleInstance.serverless.configurationInput.systemsManager.documents = [
+        {
+          name: 'test',
+          type: 'Command',
+          content: {},
+          targetType: "/AWS::EC2::Instance"
+        }
+      ];
+
+      await moduleInstance.packageDocuments();
+
+      expect(moduleInstance.serverless.service.provider.compiledCloudFormationTemplate.Resources).toHaveProperty('testCommand');
+      const parameter = moduleInstance.serverless.service.provider.compiledCloudFormationTemplate.Resources.testCommand;
+      
+      expect(parameter).toHaveProperty('Type', 'AWS::SSM::Document');
+      expect(parameter.Properties).toHaveProperty('Name', 'test');
+      expect(parameter.Properties).toHaveProperty('DocumentType', 'Command');
+      expect(parameter.Properties).toHaveProperty('DocumentFormat', 'JSON');
+      expect(parameter.Properties).toHaveProperty('Content', {});
+      expect(parameter.Properties).toHaveProperty('TargetType', "/AWS::EC2::Instance");
+    });
+
+    it('should add updateMethod type to CloudFormation template', async () => {
+      moduleInstance.serverless.configurationInput.systemsManager.documents = [
+        {
+          name: 'test',
+          type: 'Command',
+          content: {},
+          updateMethod: "NewVersion"
+        }
+      ];
+
+      await moduleInstance.packageDocuments();
+
+      expect(moduleInstance.serverless.service.provider.compiledCloudFormationTemplate.Resources).toHaveProperty('testCommand');
+      const parameter = moduleInstance.serverless.service.provider.compiledCloudFormationTemplate.Resources.testCommand;
+      
+      expect(parameter).toHaveProperty('Type', 'AWS::SSM::Document');
+      expect(parameter.Properties).toHaveProperty('Name', 'test');
+      expect(parameter.Properties).toHaveProperty('DocumentType', 'Command');
+      expect(parameter.Properties).toHaveProperty('DocumentFormat', 'JSON');
+      expect(parameter.Properties).toHaveProperty('Content', {});
+      expect(parameter.Properties).toHaveProperty('UpdateMethod', "NewVersion");
+    });
+
+    it('should add versionName type to CloudFormation template', async () => {
+      moduleInstance.serverless.configurationInput.systemsManager.documents = [
+        {
+          name: 'test',
+          type: 'Command',
+          content: {},
+          versionName: "Release1"
+        }
+      ];
+
+      await moduleInstance.packageDocuments();
+
+      expect(moduleInstance.serverless.service.provider.compiledCloudFormationTemplate.Resources).toHaveProperty('testCommand');
+      const parameter = moduleInstance.serverless.service.provider.compiledCloudFormationTemplate.Resources.testCommand;
+      
+      expect(parameter).toHaveProperty('Type', 'AWS::SSM::Document');
+      expect(parameter.Properties).toHaveProperty('Name', 'test');
+      expect(parameter.Properties).toHaveProperty('DocumentType', 'Command');
+      expect(parameter.Properties).toHaveProperty('DocumentFormat', 'JSON');
+      expect(parameter.Properties).toHaveProperty('Content', {});
+      expect(parameter.Properties).toHaveProperty('VersionName', "Release1");
+    });
+
+    it('should add requires to CloudFormation template', async () => {
+      moduleInstance.serverless.configurationInput.systemsManager.documents = [
+        {
+          name: 'test',
+          type: 'Command',
+          content: {},
+          requires: [{version: "$LATEST",name: "requiredDocument"}]
+        }
+      ];
+
+      await moduleInstance.packageDocuments();
+
+      expect(moduleInstance.serverless.service.provider.compiledCloudFormationTemplate.Resources).toHaveProperty('testCommand');
+      const parameter = moduleInstance.serverless.service.provider.compiledCloudFormationTemplate.Resources.testCommand;
+      
+      expect(parameter).toHaveProperty('Type', 'AWS::SSM::Document');
+      expect(parameter.Properties).toHaveProperty('Name', 'test');
+      expect(parameter.Properties).toHaveProperty('DocumentType', 'Command');
+      expect(parameter.Properties).toHaveProperty('DocumentFormat', 'JSON');
+      expect(parameter.Properties).toHaveProperty('Content', {});
+      expect(parameter.Properties).toHaveProperty('Requires', [{Version: "$LATEST",Name: "requiredDocument"}]);
+    });
+
+    it('should add requires version to CloudFormation template', async () => {
+      moduleInstance.serverless.configurationInput.systemsManager.documents = [
+        {
+          name: 'test',
+          type: 'Command',
+          content: {},
+          requires: [{name: "requiredDocument"}]
+        }
+      ];
+
+      await moduleInstance.packageDocuments();
+
+      expect(moduleInstance.serverless.service.provider.compiledCloudFormationTemplate.Resources).toHaveProperty('testCommand');
+      const parameter = moduleInstance.serverless.service.provider.compiledCloudFormationTemplate.Resources.testCommand;
+      
+      expect(parameter).toHaveProperty('Type', 'AWS::SSM::Document');
+      expect(parameter.Properties).toHaveProperty('Name', 'test');
+      expect(parameter.Properties).toHaveProperty('DocumentType', 'Command');
+      expect(parameter.Properties).toHaveProperty('DocumentFormat', 'JSON');
+      expect(parameter.Properties).toHaveProperty('Content', {});
+      expect(parameter.Properties).toHaveProperty('Requires', [{Name: "requiredDocument"}]);
+    });
+
+    it('should add attachments to CloudFormation template', async () => {
+      moduleInstance.serverless.configurationInput.systemsManager.documents = [
+        {
+          name: 'test',
+          type: 'Command',
+          content: {},
+          attachments: [{key: "AttachmentReference",name: "requiredDocument", values: [ "arn:aws:ssm:us-east-2:111122223333:document/OtherAccountDocument/3/their-file.py" ]}]
+        }
+      ];
+
+      await moduleInstance.packageDocuments();
+
+      expect(moduleInstance.serverless.service.provider.compiledCloudFormationTemplate.Resources).toHaveProperty('testCommand');
+      const parameter = moduleInstance.serverless.service.provider.compiledCloudFormationTemplate.Resources.testCommand;
+
+      expect(parameter).toHaveProperty('Type', 'AWS::SSM::Document');
+      expect(parameter.Properties).toHaveProperty('Name', 'test');
+      expect(parameter.Properties).toHaveProperty('DocumentType', 'Command');
+      expect(parameter.Properties).toHaveProperty('DocumentFormat', 'JSON');
+      expect(parameter.Properties).toHaveProperty('Content', {});
+      expect(parameter.Properties).toHaveProperty('Attachments', [{Key: "AttachmentReference",Name: "requiredDocument", Values: [ "arn:aws:ssm:us-east-2:111122223333:document/OtherAccountDocument/3/their-file.py" ]}]);
+    });
+
+    it('should not add attachments name to CloudFormation template', async () => {
+      moduleInstance.serverless.configurationInput.systemsManager.documents = [
+        {
+          name: 'test',
+          type: 'Command',
+          content: {},
+          attachments: [{key: "AttachmentReference", values: [ "arn:aws:ssm:us-east-2:111122223333:document/OtherAccountDocument/3/their-file.py" ]}]
+        }
+      ];
+
+      await moduleInstance.packageDocuments();
+
+      expect(moduleInstance.serverless.service.provider.compiledCloudFormationTemplate.Resources).toHaveProperty('testCommand');
+      const parameter = moduleInstance.serverless.service.provider.compiledCloudFormationTemplate.Resources.testCommand;
+
+      expect(parameter).toHaveProperty('Type', 'AWS::SSM::Document');
+      expect(parameter.Properties).toHaveProperty('Name', 'test');
+      expect(parameter.Properties).toHaveProperty('DocumentType', 'Command');
+      expect(parameter.Properties).toHaveProperty('DocumentFormat', 'JSON');
+      expect(parameter.Properties).toHaveProperty('Content', {});
+      expect(parameter.Properties).toHaveProperty('Attachments', [{Key: "AttachmentReference", Values: [ "arn:aws:ssm:us-east-2:111122223333:document/OtherAccountDocument/3/their-file.py" ]}]);
+    });
+    
+  })
+
+});

--- a/lib/package/parameters/packageParameters.js
+++ b/lib/package/parameters/packageParameters.js
@@ -118,29 +118,5 @@ module.exports = {
     }
     
     return BbPromise.resolve();
-  },
-
-  validateParameterArray(paramaters) {    
-    if (!Array.isArray(paramaters)) {
-      
-      const errorMessage = [
-        'parameters property is not an array',
-        ' Please check the README for more info.',
-      ].join('');
-      throw new this.serverless.classes
-        .Error(errorMessage);
-    }
-    return paramaters;
-  },
-
-  validateMandatoryPropValue(propValue, propName){
-    if(!propValue){
-      const errorMessage = [
-        `parameters ${propName} is mandatory`,
-        ' Please check the README for more info.',
-      ].join('');
-      throw new this.serverless.classes
-        .Error(errorMessage);
-    }
   }
 };

--- a/lib/package/parameters/packageParameters.test.js
+++ b/lib/package/parameters/packageParameters.test.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 const packageParameters = require('./packageParameters'); 
+const validations = require('../../utils/validations'); 
 
 describe('packageParameters', () => {
   let serverlessMock;
@@ -29,6 +30,8 @@ describe('packageParameters', () => {
 
     moduleInstance = Object.create(packageParameters);
     moduleInstance.serverless = serverlessMock;
+    moduleInstance.validateParameterArray = validations.validateParameterArray
+    moduleInstance.validateMandatoryPropValue = validations.validateMandatoryPropValue
   });
 
   describe('packageParameters', () => {
@@ -37,9 +40,19 @@ describe('packageParameters', () => {
 
       console.log = jest.fn();
 
-      await moduleInstance.packageParameters();
+      const value = await moduleInstance.packageParameters();
 
-      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Warning: Systems Manager config was not provided'));
+      expect(value).toBeUndefined()
+    });
+
+    it('should do nothing if parameters is not provided', async () => {
+      moduleInstance.serverless.configurationInput.systemsManager = {
+        parameters: null
+      };
+
+      const value = await moduleInstance.packageParameters();
+
+      expect(value).toBeUndefined()
     });
 
 
@@ -263,30 +276,6 @@ describe('packageParameters', () => {
     });
   });
 
-  describe('validateParameterArray', () => {
-    it('should throw an error if input is not an array', () => {
-      expect(() => moduleInstance.validateParameterArray(null)).toThrowError(
-        new serverlessMock.classes.Error('parameters property is not an array Please check the README for more info.')
-      );
-    });
-
-    it('should return the same array if input is valid', () => {
-      const result = moduleInstance.validateParameterArray([{}]);
-      expect(result).toEqual([{}]);
-    });
-  });
-
-  describe('validateMandatoryPropValue', () => {
-    it('should throw an error if property value is missing', () => {
-      expect(() => moduleInstance.validateMandatoryPropValue(null, 'testProp')).toThrowError(
-        new serverlessMock.classes.Error('parameters testProp is mandatory Please check the README for more info.')
-      );
-    });
-
-    it('should not throw an error if property value is present', () => {
-      expect(() => moduleInstance.validateMandatoryPropValue('value', 'testProp')).not.toThrow();
-    });
-  });
 
   it('should throw error if the policy provided is not valid', async () => {
     moduleInstance.serverless.configurationInput.systemsManager.parameters = [

--- a/lib/utils/validations.js
+++ b/lib/utils/validations.js
@@ -1,0 +1,39 @@
+
+
+module.exports = {
+  validateParameterArray(paramaters) {    
+      if (!Array.isArray(paramaters)) {
+        
+        const errorMessage = [
+          'parameters property is not an array',
+          ' Please check the README for more info.',
+        ].join('');
+        throw new this.serverless.classes
+          .Error(errorMessage);
+      }
+      return paramaters;
+    },
+  
+  validateMandatoryPropValue(propValue, propName){
+    if(!propValue){
+      const errorMessage = [
+        `parameters ${propName} is mandatory`,
+        ' Please check the README for more info.',
+      ].join('');
+      throw new this.serverless.classes
+        .Error(errorMessage);
+    }
+  },
+
+  validateReservedNamePrefix(name, reserveNames){
+    if(reserveNames.includes(name)){
+      const errorMessage = [
+        `${name} name is reserved by AWS `,
+        `Reserve Names: ${reserveNames}`,
+        ' Please check the README for more info.',
+      ].join('');
+      throw new this.serverless.classes
+        .Error(errorMessage);
+    }
+  }
+}

--- a/lib/utils/validations.test.js
+++ b/lib/utils/validations.test.js
@@ -1,0 +1,58 @@
+const validations = require('./validations'); 
+
+describe('validations', () => {
+
+  let serverlessMock;
+  let moduleInstance;
+
+  beforeEach(() => {
+    serverlessMock = {
+      classes: {
+        Error: class extends Error {},
+      }
+    };
+
+    moduleInstance = Object.create(validations);
+    moduleInstance.serverless = serverlessMock;
+  });
+
+  describe('validateMandatoryPropValue', () => {
+    it('should throw an error if property value is missing', () => {
+      expect(() => moduleInstance.validateMandatoryPropValue(null, 'testProp')).toThrowError(
+        new serverlessMock.classes.Error('parameters testProp is mandatory Please check the README for more info.')
+      );
+    });
+
+    it('should not throw an error if property value is present', () => {
+      expect(() => moduleInstance.validateMandatoryPropValue('value', 'testProp')).not.toThrow();
+    });
+  });
+
+  describe('validateParameterArray', () => {
+    it('should throw an error if input is not an array', () => {
+      expect(() => moduleInstance.validateParameterArray(null)).toThrowError(
+        new serverlessMock.classes.Error('parameters property is not an array Please check the README for more info.')
+      );
+    });
+
+    it('should return the same array if input is valid', () => {
+      const result = moduleInstance.validateParameterArray([{}]);
+      expect(result).toEqual([{}]);
+    });
+  });
+
+  describe('validateReservedNamePrefix', () => {
+    const reservedNames= [ "aws", "amazon", "amzn", "AWSEC2", "AWSConfigRemediationAWSSupport" ];
+    it('should throw an error if input is reserved name', () => {
+      expect(() => moduleInstance.validateReservedNamePrefix('aws', reservedNames)).toThrowError(
+        new serverlessMock.classes.Error('aws name is reserved by AWS Reserve Names: aws,amazon,amzn,AWSEC2,AWSConfigRemediationAWSSupport Please check the README for more info.')
+      );
+    });
+
+    it('should return the same array if input is valid', () => {
+      const result = moduleInstance.validateReservedNamePrefix('test', reservedNames);
+      expect(result).toBeUndefined()
+    });
+  });
+    
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-systems-manager",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "This module is Systems Manager plugin for Serverless Framework",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
- Support for AWS Documents
- Fix: test for missig SystemsManager property
- Fix: test for missig parameter property
- Centralized validations in proper module
- Fix: replace custop prop for systemsManager in README
- Add: Documents support documentation in README